### PR TITLE
JSR310のテストがSQLServerで失敗していたため対応

### DIFF
--- a/src/test/java/nablarch/common/dao/UniversalDaoWithJsr310Test.java
+++ b/src/test/java/nablarch/common/dao/UniversalDaoWithJsr310Test.java
@@ -1,12 +1,15 @@
 package nablarch.common.dao;
 
 import nablarch.common.dao.entity.Jsr310Column;
+import nablarch.common.dao.entity.Jsr310ColumnForSqlServer;
 import nablarch.core.db.connection.ConnectionFactory;
 import nablarch.core.db.connection.DbConnectionContext;
 import nablarch.core.db.connection.TransactionManagerConnection;
 import nablarch.core.transaction.TransactionContext;
 import nablarch.test.support.SystemRepositoryResource;
 import nablarch.test.support.db.helper.DatabaseTestRunner;
+import nablarch.test.support.db.helper.TargetDb;
+import nablarch.test.support.db.helper.TargetDb.Db;
 import nablarch.test.support.db.helper.VariousDbTestHelper;
 import org.junit.After;
 import org.junit.Before;
@@ -24,6 +27,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * {{@link UniversalDao}のテストクラス。
  * <p> 
  * Date and Time API（JSR-310）型の登録、検索の動作確認テストを実施する。
+ * Entityクラスの日時型の定義方法がSQLServerとそれ以外のDBで異なるため、分けてテストを実施する。
+ * 
  */
 @RunWith(DatabaseTestRunner.class)
 public class UniversalDaoWithJsr310Test {
@@ -51,9 +56,10 @@ public class UniversalDaoWithJsr310Test {
     }
 
     /**
-     * Date and Time API（JSR-310）型（{@link LocalDate}, {@link LocalDateTime}）のフィールドを持つEntityのデータを登録できること
+     * Date and Time API（JSR-310）型（{@link LocalDate}, {@link LocalDateTime}）のフィールドを持つEntityのデータを登録できること（SQLServer以外）。
      */
     @Test
+    @TargetDb(exclude = Db.SQL_SERVER)
     public void test_insertJsr310Column() throws Exception {
         VariousDbTestHelper.createTable(Jsr310Column.class);
         final Jsr310Column entity = new Jsr310Column();
@@ -69,9 +75,29 @@ public class UniversalDaoWithJsr310Test {
     }
 
     /**
-     * Date and Time API（JSR-310）型（{@link LocalDate}, {@link LocalDateTime}）のフィールドを持つEntityのデータを更新できること
+     * Date and Time API（JSR-310）型（{@link LocalDate}, {@link LocalDateTime}）のフィールドを持つEntityのデータを登録できること（SQLServer用）。
      */
     @Test
+    @TargetDb(include = Db.SQL_SERVER)
+    public void test_insertJsr310Column_SQLServer() throws Exception {
+        VariousDbTestHelper.createTable(Jsr310ColumnForSqlServer.class);
+        final Jsr310ColumnForSqlServer entity = new Jsr310ColumnForSqlServer();
+        entity.id = 1L;
+        entity.localDate = LocalDate.parse("2015-04-01");
+        entity.localDateTime =  LocalDateTime.parse("2015-04-01T12:34:56");
+        UniversalDao.insert(entity);
+        connection.commit();
+
+        final Jsr310ColumnForSqlServer actual = VariousDbTestHelper.findById(Jsr310ColumnForSqlServer.class, entity.id);
+        assertThat(actual.localDate, is(entity.localDate));
+        assertThat(actual.localDateTime, is(entity.localDateTime));
+    }
+    
+    /**
+     * Date and Time API（JSR-310）型（{@link LocalDate}, {@link LocalDateTime}）のフィールドを持つEntityのデータを更新できること（SQLServer以外）。
+     */
+    @Test
+    @TargetDb(exclude = Db.SQL_SERVER)
     public void test_updateJsr310Column() throws Exception {
         VariousDbTestHelper.createTable(Jsr310Column.class);
         final Jsr310Column entity = new Jsr310Column();
@@ -92,9 +118,34 @@ public class UniversalDaoWithJsr310Test {
     }
 
     /**
-     * {@link UniversalDao#findBySqlFile(Class, String, Object)}を使用して{@link LocalDate}でのデータ検索ができること。
+     * Date and Time API（JSR-310）型（{@link LocalDate}, {@link LocalDateTime}）のフィールドを持つEntityのデータを更新できること（SQLServer用）。
      */
     @Test
+    @TargetDb(include = Db.SQL_SERVER)
+    public void test_updateJsr310Column_SQLServer() throws Exception {
+        VariousDbTestHelper.createTable(Jsr310ColumnForSqlServer.class);
+        final Jsr310ColumnForSqlServer entity = new Jsr310ColumnForSqlServer();
+        entity.id = 12345L;
+        entity.localDate = LocalDate.parse("2015-04-01");
+        entity.localDateTime =  LocalDateTime.parse("2015-04-01T12:34:56");
+        VariousDbTestHelper.insert(entity);
+
+        entity.localDate = LocalDate.parse("2014-03-31");
+        entity.localDateTime =  LocalDateTime.parse("2014-03-31T01:23:45");
+        UniversalDao.update(entity);
+        connection.commit();
+
+        final Jsr310ColumnForSqlServer actual = VariousDbTestHelper.findById(Jsr310ColumnForSqlServer.class, entity.id);
+        assertThat(actual.localDate, is(entity.localDate));
+        assertThat(actual.localDateTime, is(entity.localDateTime));
+
+    }
+    
+    /**
+     * {@link UniversalDao#findBySqlFile(Class, String, Object)}を使用して{@link LocalDate}でのデータ検索ができること（SQLServer以外）。
+     */
+    @Test
+    @TargetDb(exclude = Db.SQL_SERVER)
     public void test_findAllBySqlFile_localDate() throws Exception {
         VariousDbTestHelper.createTable(Jsr310Column.class);
         final Jsr310Column entity = new Jsr310Column();
@@ -111,9 +162,30 @@ public class UniversalDaoWithJsr310Test {
     }
 
     /**
-     * {@link UniversalDao#findBySqlFile(Class, String, Object)}を使用して{@link LocalDateTime}でのデータ検索ができること。
+     * {@link UniversalDao#findBySqlFile(Class, String, Object)}を使用して{@link LocalDate}でのデータ検索ができること（SQLServer用）。
      */
     @Test
+    @TargetDb(include = Db.SQL_SERVER)
+    public void test_findAllBySqlFile_localDate_SQLServer() throws Exception {
+        VariousDbTestHelper.createTable(Jsr310ColumnForSqlServer.class);
+        final Jsr310ColumnForSqlServer entity = new Jsr310ColumnForSqlServer();
+        entity.id = 12345L;
+        entity.localDate = LocalDate.parse("2015-04-01");
+        VariousDbTestHelper.insert(entity);
+
+        // DBによってDateを保持する精度が異なるため、「指定したlocalDate以降であること」を検索条件とする
+        final EntityList<Jsr310ColumnForSqlServer> actual = UniversalDao.findAllBySqlFile(Jsr310ColumnForSqlServer.class,
+            "find_where_local_date_greater_than", new Object[] { entity.localDate.minusDays(1) });
+
+        assertThat(actual.size(), is(1));
+        assertThat(actual.get(0).localDate, is(entity.localDate));
+    }
+    
+    /**
+     * {@link UniversalDao#findBySqlFile(Class, String, Object)}を使用して{@link LocalDateTime}でのデータ検索ができること（SQLServer以外）。
+     */
+    @Test
+    @TargetDb(exclude = Db.SQL_SERVER)
     public void test_findAllBySqlFile_localDateTime() throws Exception {
         VariousDbTestHelper.createTable(Jsr310Column.class);
         final Jsr310Column entity = new Jsr310Column();
@@ -124,6 +196,26 @@ public class UniversalDaoWithJsr310Test {
         // DBによってTimestampを保持する精度が異なるため、「指定したlocalDateTime以降であること」を検索条件とする
         final EntityList<Jsr310Column> actual = UniversalDao.findAllBySqlFile(Jsr310Column.class,
                 "find_where_local_date_time_greater_than", new Object[] { entity.localDateTime.minusMinutes(1) });
+
+        assertThat(actual.size(), is(1));
+        assertThat(actual.get(0).localDateTime, is(entity.localDateTime));
+    }
+
+    /**
+     * {@link UniversalDao#findBySqlFile(Class, String, Object)}を使用して{@link LocalDateTime}でのデータ検索ができること（SQLServer用）。
+     */
+    @Test
+    @TargetDb(include = Db.SQL_SERVER)
+    public void test_findAllBySqlFile_localDateTime_SQLServer() throws Exception {
+        VariousDbTestHelper.createTable(Jsr310ColumnForSqlServer.class);
+        final Jsr310ColumnForSqlServer entity = new Jsr310ColumnForSqlServer();
+        entity.id = 12345L;
+        entity.localDateTime =  LocalDateTime.parse("2015-04-01T12:34:56");
+        VariousDbTestHelper.insert(entity);
+
+        // DBによってTimestampを保持する精度が異なるため、「指定したlocalDateTime以降であること」を検索条件とする
+        final EntityList<Jsr310ColumnForSqlServer> actual = UniversalDao.findAllBySqlFile(Jsr310ColumnForSqlServer.class,
+            "find_where_local_date_time_greater_than", new Object[] { entity.localDateTime.minusMinutes(1) });
 
         assertThat(actual.size(), is(1));
         assertThat(actual.get(0).localDateTime, is(entity.localDateTime));

--- a/src/test/java/nablarch/common/dao/entity/Jsr310ColumnForSqlServer.java
+++ b/src/test/java/nablarch/common/dao/entity/Jsr310ColumnForSqlServer.java
@@ -3,20 +3,18 @@ package nablarch.common.dao.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
- * Date and Time API（JSR-310）の型（{@link LocalDate}, {@link LocalDateTime}）の動作検証用エンティティ（SQLServer以外）
+ * Date and Time API（JSR-310）の型（{@link LocalDate}, {@link LocalDateTime}）の動作検証用エンティティ（SQLServer用）
  */
 @SuppressWarnings("JpaDataSourceORMInspection")
 @Entity
-@Table(name = "jsr310_column")
-public class Jsr310Column {
+@Table(name = "jsr310_column_sqlserver")
+public class Jsr310ColumnForSqlServer {
 
     @Id
     @Column(name = "id", length = 18)
@@ -25,7 +23,8 @@ public class Jsr310Column {
     @Column(name = "local_date", columnDefinition = "date")
     public LocalDate localDate;
 
-    @Column(name = "local_date_time", columnDefinition = "timestamp")
+    // "timestamp"で生成されるTIMESTAMP型はSQLSererだと日時型ではないため、DATEIME2型にする
+    @Column(name = "local_date_time", columnDefinition = "datetime2")
     public LocalDateTime localDateTime;
 
     @Id

--- a/src/test/resources/entity.list.txt
+++ b/src/test/resources/entity.list.txt
@@ -8,3 +8,4 @@ nablarch.common.dao.UniversalDaoFieldTest$Users
 nablarch.common.dao.entity.DatePkTable
 nablarch.common.dao.entity.TimestampPkTablele
 nablarch.common.dao.entity.Jsr310Column
+nablarch.common.dao.entity.Jsr310ColumnForSqlServer

--- a/src/test/resources/nablarch/common/dao/entity/Jsr310ColumnForSqlServer.sql
+++ b/src/test/resources/nablarch/common/dao/entity/Jsr310ColumnForSqlServer.sql
@@ -1,0 +1,9 @@
+find_where_local_date_greater_than =
+select *
+from jsr310_column_sqlserver
+where local_date > ?
+
+find_where_local_date_time_greater_than =
+select *
+from jsr310_column_sqlserver
+where local_date_time > ?


### PR DESCRIPTION
## 背景

テストでは`VariousDbTestHelper`を使用してEntityクラスから動的にテーブルを生成しているが、`timestamp`定義で生成される型がSQL Serverだと日時用ではない型が生成されてしまい、テストが失敗していた。

## 対応概要

SQL ServerだけEntityクラスとテストを分けることで対応した。