### PR TITLE
UniversalDao.Transactionを公開APIとして追加

### DIFF
--- a/src/main/java/nablarch/common/dao/UniversalDao.java
+++ b/src/main/java/nablarch/common/dao/UniversalDao.java
@@ -472,6 +472,7 @@ public final class UniversalDao {
      * @author kawasima
      * @author Hisaaki Shioiri
      */
+    @Published
     public abstract static class Transaction extends SimpleDbTransactionExecutor<Void> {
 
         /**


### PR DESCRIPTION
[解説書内](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/libraries/database/universal_dao.html?_ijt=gj5ltq091gi58ro1fkbun26t6s&_ij_reload=RELOAD_ON_SAVE#universal-dao-transaction)で継承が案内されていたが、Transactionクラス自体は公開APIとなっていなかったため修正しました。